### PR TITLE
Move FunctionObjectRef::call function to ObjectRef. because some Obje…

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -905,6 +905,16 @@ void ObjectRef::enumerateObjectOwnProperies(ExecutionStateRef* state, const std:
                               (void*)&cb);
 }
 
+ValueRef* ObjectRef::call(ExecutionStateRef* state, ValueRef* receiver, const size_t argc, ValueRef** argv)
+{
+    Object* o = toImpl(this);
+    Value* newArgv = ALLOCA(sizeof(Value) * argc, Value, state);
+    for (size_t i = 0; i < argc; i++) {
+        newArgv[i] = toImpl(argv[i]);
+    }
+    return toRef(Object::call(*toImpl(state), o, toImpl(receiver), argc, newArgv));
+}
+
 FunctionObjectRef* GlobalObjectRef::object()
 {
     return toRef(toImpl(this)->object());
@@ -1283,16 +1293,6 @@ bool FunctionObjectRef::isConstructor()
 {
     FunctionObject* o = toImpl(this);
     return o->isConstructor();
-}
-
-ValueRef* FunctionObjectRef::call(ExecutionStateRef* state, ValueRef* receiver, const size_t argc, ValueRef** argv)
-{
-    FunctionObject* o = toImpl(this);
-    Value* newArgv = ALLOCA(sizeof(Value) * argc, Value, state);
-    for (size_t i = 0; i < argc; i++) {
-        newArgv[i] = toImpl(argv[i]);
-    }
-    return toRef(Object::call(*toImpl(state), o, toImpl(receiver), argc, newArgv));
 }
 
 static void markEvalToCodeblock(InterpretedCodeBlock* cb)

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -542,6 +542,8 @@ public:
 
     void enumerateObjectOwnProperies(ExecutionStateRef* state, const std::function<bool(ExecutionStateRef* state, ValueRef* propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>& cb);
 
+    ValueRef* call(ExecutionStateRef* state, ValueRef* receiver, const size_t argc, ValueRef** argv);
+
     bool isExtensible(ExecutionStateRef* state);
     bool preventExtensions(ExecutionStateRef* state);
 
@@ -653,8 +655,6 @@ public:
     bool setFunctionPrototype(ExecutionStateRef* state, ValueRef* v);
 
     bool isConstructor();
-    ValueRef* call(ExecutionStateRef* state, ValueRef* receiver, const size_t argc, ValueRef** argv);
-
     void markFunctionNeedsSlowVirtualIdentifierOperation();
 };
 


### PR DESCRIPTION
…ctRef is Callable now

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>